### PR TITLE
docs: clarify Python version requirement due to NumPy 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Spanish and Portuguese versions of the challenge rules and problem description c
 
 - Java 17
 - Maven
-- Python 3.8 or higher
+- Python 3.10 or higher (required due to NumPy 2.x)
 - CPLEX 22.11 (optional)
 - OR-Tools 9.11 (optional)
 


### PR DESCRIPTION
This updates the documented Python requirement to 3.10+, which is required by NumPy 2.x. This aligns the README with the actual dependency constraints and avoids installation issues on Python 3.8.